### PR TITLE
Centralize React and TypeScript config

### DIFF
--- a/apps/web-a/package.json
+++ b/apps/web-a/package.json
@@ -15,8 +15,6 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
     "vite": "^4.0.0",
-    "tailwindcss": "^3.3.0",
-    "postcss": "^8.4.0",
     "autoprefixer": "^10.4.0"
   }
 }

--- a/apps/web-a/package.json
+++ b/apps/web-a/package.json
@@ -10,15 +10,10 @@
     "type-check": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@my/utils": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "@my/utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
     "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.0.0",
     "vite": "^4.0.0",
     "tailwindcss": "^3.3.0",
     "postcss": "^8.4.0",

--- a/apps/web-a/tsconfig.json
+++ b/apps/web-a/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "jsx": "react-jsx"
-  }
+  "include": ["src"]
 }

--- a/apps/web-b/package.json
+++ b/apps/web-b/package.json
@@ -15,8 +15,6 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
     "vite": "^4.0.0",
-    "tailwindcss": "^3.3.0",
-    "postcss": "^8.4.0",
     "autoprefixer": "^10.4.0"
   }
 }

--- a/apps/web-b/package.json
+++ b/apps/web-b/package.json
@@ -10,15 +10,10 @@
     "type-check": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@my/utils": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "@my/utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
     "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.0.0",
     "vite": "^4.0.0",
     "tailwindcss": "^3.3.0",
     "postcss": "^8.4.0",

--- a/apps/web-b/tsconfig.json
+++ b/apps/web-b/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "jsx": "react-jsx"
-  }
+  "include": ["src"]
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "react-dom": "^18.2.0",
     "typescript": "^5.0.0",
     "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0"
+    "@types/react-dom": "^18.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "eslint-plugin-react": "^7.33.2",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
-    "eslint-config-prettier": "^9.1.0"
+    "eslint-config-prettier": "^9.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,9 +14,5 @@
   },
   "peerDependencies": {
     "react": "^18.0.0"
-  },
-  "devDependencies": {
-    "@types/react": "^18.0.0",
-    "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- hoist React & TypeScript dependencies to the repo root
- rely on root tsconfig for React JSX setup

## Testing
- `pnpm install` *(fails: Request was cancelled)*
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm type-check` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1816be883219715dd837cbbcf4c