### PR TITLE
Update React to v19.1.0

### DIFF
--- a/apps/web-a/package.json
+++ b/apps/web-a/package.json
@@ -10,10 +10,14 @@
     "type-check": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@my/utils": "workspace:*"
+    "@my/utils": "workspace:*",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   }
 }

--- a/apps/web-b/package.json
+++ b/apps/web-b/package.json
@@ -10,10 +10,14 @@
     "type-check": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@my/utils": "workspace:*"
+    "@my/utils": "workspace:*",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.4",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
     "autoprefixer": "^10.4.21",
@@ -27,8 +27,8 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.33.2",
     "postcss": "^8.4.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "tailwindcss": "^3.3.0",
     "turbo": "^2.5.4",
     "typescript": "^5.0.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,5 +12,14 @@
     "build": "tsc -p tsconfig.json",
     "lint": "eslint . --ext ts,tsx",
     "type-check": "tsc -p tsconfig.json --noEmit"
+  },
+  "peerDependencies": {
+    "react": "^19.1.0"
+  },
+  "devDependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump React-related packages to v19 across workspace

## Testing
- `pnpm install` *(fails: request to registry.npmjs.org blocked)*
- `pnpm lint` *(fails: request to registry.npmjs.org blocked)*
- `pnpm type-check` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68452968ba688321b358d50fad6a02d4