### PR TITLE
Add item page with routing

### DIFF
--- a/apps/web-a/src/AddItemPage.tsx
+++ b/apps/web-a/src/AddItemPage.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { Input, Select, Button } from '@my/utils';
+
+export const AddItemPage: React.FC = () => {
+  const [title, setTitle] = useState('');
+  const [status, setStatus] = useState<'active' | 'inactive'>('active');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert(`Added ${title} (${status})`);
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h1 className="text-2xl font-semibold mb-6">Add New Item</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          className="w-full"
+        />
+        <Select
+          value={status}
+          onChange={(e) => setStatus(e.target.value as 'active' | 'inactive')}
+          className="w-full"
+        >
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+        </Select>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </form>
+    </div>
+  );
+};

--- a/apps/web-a/src/CMSPage.tsx
+++ b/apps/web-a/src/CMSPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, ReactElement } from 'react';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import {
   Input,
@@ -57,6 +58,7 @@ export const CMSPage: React.FC = () => {
   const [query, setQuery] = useState('');
   const [status, setStatus] = useState('all');
   const [page, setPage] = useState(1);
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchItems(page).then((res) => setItems(res.data));
@@ -96,6 +98,9 @@ export const CMSPage: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto px-4 py-8">
       <h1 className="text-2xl font-semibold text-gray-900 mb-8">{greet('web-a')}</h1>
+      <div className="mb-4 flex justify-end">
+        <Button onClick={() => navigate('/add-item')}>Add Item</Button>
+      </div>
       <div className="bg-white rounded-lg p-6">
         <div className="flex flex-col md:flex-row gap-4 mb-6">
           <div className="flex-1">

--- a/apps/web-a/src/CMSPage.tsx
+++ b/apps/web-a/src/CMSPage.tsx
@@ -98,9 +98,6 @@ export const CMSPage: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto px-4 py-8">
       <h1 className="text-2xl font-semibold text-gray-900 mb-8">{greet('web-a')}</h1>
-      <div className="mb-4 flex justify-end">
-        <Button onClick={() => navigate('/add-item')}>Add Item</Button>
-      </div>
       <div className="bg-white rounded-lg p-6">
         <div className="flex flex-col md:flex-row gap-4 mb-6">
           <div className="flex-1">
@@ -126,6 +123,7 @@ export const CMSPage: React.FC = () => {
           >
             Search
           </Button>
+          <Button onClick={() => navigate('/add-item')}>Add Item</Button>
         </div>
 
         <div className="overflow-x-auto rounded-lg border border-gray-200">

--- a/apps/web-a/src/main.tsx
+++ b/apps/web-a/src/main.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { CMSPage } from './CMSPage';
-import { greet } from '@my/utils'
+import { AddItemPage } from './AddItemPage';
+import { greet } from '@my/utils';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <div className="p-4">
-      <CMSPage />
-    </div>
-  </React.StrictMode>
+    <BrowserRouter>
+      <div className="p-4">
+        <Routes>
+          <Route path="/" element={<CMSPage />} />
+          <Route path="/add-item" element={<AddItemPage />} />
+        </Routes>
+      </div>
+    </BrowserRouter>
+  </React.StrictMode>,
 );

--- a/apps/web-a/src/main.tsx
+++ b/apps/web-a/src/main.tsx
@@ -4,7 +4,6 @@ import './index.css';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { CMSPage } from './CMSPage';
 import { AddItemPage } from './AddItemPage';
-import { greet } from '@my/utils';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/apps/web-b/src/AddItemPage.tsx
+++ b/apps/web-b/src/AddItemPage.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { Input, Select, Button } from '@my/utils';
+
+export const AddItemPage: React.FC = () => {
+  const [title, setTitle] = useState('');
+  const [status, setStatus] = useState<'active' | 'inactive'>('active');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert(`Added ${title} (${status})`);
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h1 className="text-2xl font-semibold mb-6">Add New Item</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          className="w-full"
+        />
+        <Select
+          value={status}
+          onChange={(e) => setStatus(e.target.value as 'active' | 'inactive')}
+          className="w-full"
+        >
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+        </Select>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </form>
+    </div>
+  );
+};

--- a/apps/web-b/src/CMSPage.tsx
+++ b/apps/web-b/src/CMSPage.tsx
@@ -98,9 +98,6 @@ export const CMSPage: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto px-4 py-8">
       <h1 className="text-2xl font-semibold text-gray-900 mb-8">{greet('web-b')}</h1>
-      <div className="mb-4 flex justify-end">
-        <Button onClick={() => navigate('/add-item')}>Add Item</Button>
-      </div>
       <div className="bg-white rounded-lg p-6">
         <div className="flex flex-col md:flex-row gap-4 mb-6">
           <div className="flex-1">
@@ -126,6 +123,7 @@ export const CMSPage: React.FC = () => {
           >
             Search
           </Button>
+          <Button onClick={() => navigate('/add-item')}>Add Item</Button>
         </div>
 
         <div className="overflow-x-auto rounded-lg border border-gray-200">

--- a/apps/web-b/src/CMSPage.tsx
+++ b/apps/web-b/src/CMSPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, ReactElement } from 'react';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import {
   Input,
@@ -57,6 +58,7 @@ export const CMSPage: React.FC = () => {
   const [query, setQuery] = useState('');
   const [status, setStatus] = useState('all');
   const [page, setPage] = useState(1);
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchItems(page).then((res) => setItems(res.data));
@@ -96,6 +98,9 @@ export const CMSPage: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto px-4 py-8">
       <h1 className="text-2xl font-semibold text-gray-900 mb-8">{greet('web-b')}</h1>
+      <div className="mb-4 flex justify-end">
+        <Button onClick={() => navigate('/add-item')}>Add Item</Button>
+      </div>
       <div className="bg-white rounded-lg p-6">
         <div className="flex flex-col md:flex-row gap-4 mb-6">
           <div className="flex-1">

--- a/apps/web-b/src/main.tsx
+++ b/apps/web-b/src/main.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { CMSPage } from './CMSPage';
-import { greet } from "@my/utils";
+import { AddItemPage } from './AddItemPage';
+import { greet } from '@my/utils';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <div className="p-4">
-      <CMSPage />
-    </div>
-  </React.StrictMode>
+    <BrowserRouter>
+      <div className="p-4">
+        <Routes>
+          <Route path="/" element={<CMSPage />} />
+          <Route path="/add-item" element={<AddItemPage />} />
+        </Routes>
+      </div>
+    </BrowserRouter>
+  </React.StrictMode>,
 );

--- a/apps/web-b/src/main.tsx
+++ b/apps/web-b/src/main.tsx
@@ -4,7 +4,6 @@ import './index.css';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { CMSPage } from './CMSPage';
 import { AddItemPage } from './AddItemPage';
-import { greet } from '@my/utils';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^19.1.0",
     "tailwindcss": "^3.4.17",
     "turbo": "^2.5.4",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "react-router-dom": "^6.23.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-router-dom:
+        specifier: ^6.23.0
+        version: 6.30.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17
@@ -439,6 +442,10 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@remix-run/router@1.23.0':
+    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+    engines: {node: '>=14.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.9':
     resolution: {integrity: sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==}
@@ -1612,6 +1619,19 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@6.30.1:
+    resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.30.1:
+    resolution: {integrity: sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -2425,6 +2445,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@remix-run/router@1.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.9': {}
 
@@ -3761,6 +3783,18 @@ snapshots:
   react-is@16.13.1: {}
 
   react-refresh@0.17.0: {}
+
+  react-router-dom@6.30.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router: 6.30.1(react@19.1.0)
+
+  react-router@6.30.1(react@19.1.0):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 19.1.0
 
   react@19.1.0: {}
 


### PR DESCRIPTION
## Summary
- create `AddItemPage` in both apps with simple form
- update `CMSPage` to include an **Add Item** button
- configure routing with `react-router-dom`
- declare `react-router-dom` dependency

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.1.tgz)*
- `pnpm type-check` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68452d94af7c8321955ad691f6f40389